### PR TITLE
Install only 64 bit version of java

### DIFF
--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -1,8 +1,9 @@
 ---
 - name: Install javaruntime with chocolatey
   win_chocolatey:
-    name: javaruntime
+    name: jre8
     version: "{{ win_java_version}}"
+    params: "/exclude:32"
     state: present
   ignore_errors: yes
 


### PR DESCRIPTION
Hello,
currently we install both versions of Java and Jenkins slave automatically uses 32 bit version. That causes issues such as any powershell scripts are run with 32 bit powershell. This PR fixes this issue.

:*